### PR TITLE
Create tests for multiple files

### DIFF
--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -701,7 +701,7 @@ class BioData(datasets.ArrowBasedBuilder):
                     labels = list(set(current_labels))
                 if None in labels:
                     labels.remove(None)
-                tbl = fn(tbl, current_labels, labels)
+                tbl = fn(tbl, labels, current_labels)
                 if self.config.labels is None:
                     self.config.labels = [str(label) for label in labels]
 

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -641,16 +641,15 @@ class BioData(datasets.ArrowBasedBuilder):
         from biosets.data_handling import DataHandler
 
         def fn(tbl, labels, all_labels):
-            if any(isinstance(label, str) for label in labels):
-                lab1int = {label: i for i, label in enumerate(labels)}
-                all_labels = [lab1int.get(label, -1) for label in all_labels]
-                tbl_format = DataHandler.get_format(tbl)
-                all_labels = DataHandler.to_format(all_labels, tbl_format)
-                tbl = DataHandler.append_column(
-                    tbl,
-                    self.TARGET_COLUMN,
-                    all_labels,
-                )
+            lab2int = {label: i for i, label in enumerate(labels)}
+            all_labels = [lab2int.get(label, -1) for label in all_labels]
+            tbl_format = DataHandler.get_format(tbl)
+            all_labels = DataHandler.to_format(all_labels, tbl_format)
+            tbl = DataHandler.append_column(
+                tbl,
+                self.TARGET_COLUMN,
+                all_labels,
+            )
 
             return tbl
 

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -839,7 +839,11 @@ class BioData(datasets.ArrowBasedBuilder):
 
             if self.config.target_column:
                 labels = self.config.labels
-                if not self.config.positive_labels and not self.config.negative_labels:
+                if (
+                    not self.config.positive_labels
+                    and not self.config.negative_labels
+                    and not self.config.labels
+                ):
                     if (
                         self.config.sample_metadata_files
                         and len(self.config.sample_metadata_files) == 1

--- a/tests/packaged_modules/test_biodata.py
+++ b/tests/packaged_modules/test_biodata.py
@@ -6,12 +6,6 @@ from pathlib import Path
 import pandas as pd
 import pyarrow as pa
 import pytest
-from biosets.features import Abundance
-from biosets.load import load_dataset
-from biosets.packaged_modules.biodata.biodata import BioData, BioDataConfig
-from biosets.packaged_modules.csv.csv import Csv
-from biosets.packaged_modules.npz.npz import SparseReader
-from biosets.utils import logging
 from datasets.data_files import (
     DataFilesDict,
     DataFilesList,

--- a/tests/packaged_modules/test_biodata.py
+++ b/tests/packaged_modules/test_biodata.py
@@ -15,6 +15,13 @@ from datasets.exceptions import DatasetGenerationError
 from datasets.features import Features, Value
 from datasets.packaged_modules.json.json import Json
 
+from biosets.features import Abundance
+from biosets.load import load_dataset
+from biosets.packaged_modules.biodata.biodata import BioData, BioDataConfig
+from biosets.packaged_modules.csv.csv import Csv
+from biosets.packaged_modules.npz.npz import SparseReader
+from biosets.utils import logging
+
 logger = logging.get_logger(__name__)
 
 

--- a/tests/packaged_modules/test_biodata.py
+++ b/tests/packaged_modules/test_biodata.py
@@ -1075,21 +1075,81 @@ class TestBioData(unittest.TestCase):
                 str(context.exception),
             )
 
-    # def test_biodata_load_dataset_with_multiple_files_and_with_labels(self):
-    #     data = load_dataset(
-    #         "snp",
-    #         data_files=[self.data_with_metadata, self.data_with_metadata],
-    #         feature_metadata_files=self.feature_metadata_file,
-    #         labels=["a", "b"],
-    #         target_column="target",
-    #     )["train"]
-    #     pd_data = data.to_pandas()
-    #     assert len(pd_data) == 4
-    #     assert pd_data["sample"].tolist() == [
-    #         "sample1",
-    #         "sample2",
-    #         "sample3",
-    #         "sample4",
-    #     ]
-    #     assert pd_data["target"].tolist() == ["a", "b", "c", "d"]
-    #     assert pd_data["labels"].tolist() == [0, 1, 2, 4]
+    def test_biodata_load_dataset_with_multiple_files_and_with_labels(self):
+        data = load_dataset(
+            "snp",
+            data_files=[self.data_with_metadata, self.data_with_metadata],
+            feature_metadata_files=self.feature_metadata_file,
+            labels=["a", "b"],
+            target_column="target",
+        )["train"]
+        pd_data = data.to_pandas()
+        assert len(pd_data) == 4
+        assert pd_data["sample"].tolist() == [
+            "sample1",
+            "sample2",
+            "sample1",
+            "sample2",
+        ]
+        assert pd_data["target"].tolist() == ["a", "b", "a", "b"]
+        assert set(pd_data["labels"].tolist()) == set([0, 1, 0, 1])
+
+    def test_biodata_load_dataset_with_multiple_files_and_positive_labels(self):
+        data = load_dataset(
+            "snp",
+            data_files=[self.data_with_metadata, self.data_with_metadata],
+            feature_metadata_files=self.feature_metadata_file,
+            positive_labels=["a", "b"],
+            target_column="target",
+        )["train"]
+        pd_data = data.to_pandas()
+        assert len(pd_data) == 4
+        assert pd_data["sample"].tolist() == [
+            "sample1",
+            "sample2",
+            "sample1",
+            "sample2",
+        ]
+        assert pd_data["target"].tolist() == ["a", "b", "a", "b"]
+        assert set(pd_data["labels"].tolist()) == set([1, 1, 1, 1])
+
+    def test_biodata_load_dataset_with_multiple_files_and_negative_labels(self):
+        data = load_dataset(
+            "snp",
+            data_files=[self.data_with_metadata, self.data_with_metadata],
+            feature_metadata_files=self.feature_metadata_file,
+            negative_labels=["a", "b"],
+            target_column="target",
+        )["train"]
+        pd_data = data.to_pandas()
+        assert len(pd_data) == 4
+        assert pd_data["sample"].tolist() == [
+            "sample1",
+            "sample2",
+            "sample1",
+            "sample2",
+        ]
+        assert pd_data["target"].tolist() == ["a", "b", "a", "b"]
+        assert set(pd_data["labels"].tolist()) == set([0, 0, 0, 0])
+
+    def test_biodata_load_dataset_with_multiple_sample_files_and_labels(self):
+        data = load_dataset(
+            "snp",
+            data_files=[self.npz_file, self.npz_file],
+            sample_metadata_files=[
+                self.sample_metadata_file,
+                self.sample_metadata_file_2,
+            ],
+            feature_metadata_files=self.feature_metadata_file,
+            labels=["a", "b", "c"],
+            target_column="target",
+        )["train"]
+        pd_data = data.to_pandas()
+        assert pd_data["sample"].tolist() == [
+            "sample1",
+            "sample2",
+            "sample3",
+            "sample4",
+        ]
+        assert pd_data["target"].tolist() == ["a", "b", "c", "d"]
+        assert set(pd_data["labels"].tolist()) == set([0, 1, 2, -1])


### PR DESCRIPTION
This pull request includes several changes to the `biodata` module and its associated tests. The main updates involve refactoring label handling, fixing label assignment logic, and adding new test cases to ensure data loading works correctly under various conditions.

### Refactoring and Logic Fixes:

* [`src/biosets/packaged_modules/biodata/biodata.py`](diffhunk://#diff-477f257b9fad7335fcf7adaf804049429861a58ae68d0028400422cad76b62f1L644-R645): Refactored label handling in `_set_labels` by removing redundant checks and simplifying the label-to-integer mapping.
* [`src/biosets/packaged_modules/biodata/biodata.py`](diffhunk://#diff-477f257b9fad7335fcf7adaf804049429861a58ae68d0028400422cad76b62f1L705-R704): Corrected the order of parameters in the `fn` function call to ensure labels are correctly assigned.
* [`src/biosets/packaged_modules/biodata/biodata.py`](diffhunk://#diff-477f257b9fad7335fcf7adaf804049429861a58ae68d0028400422cad76b62f1L843-R846): Added a check for the presence of `labels` in `_generate_tables` to handle cases where both positive and negative labels are not provided.

### Test Enhancements:

* [`tests/packaged_modules/test_biodata.py`](diffhunk://#diff-9ecf032a3015a72f2eab10c110f44a0e7c65543c657efd82602c1582e939dad4L9-L14): Reorganized imports with ruff. [[1]](diffhunk://#diff-9ecf032a3015a72f2eab10c110f44a0e7c65543c657efd82602c1582e939dad4L9-L14) [[2]](diffhunk://#diff-9ecf032a3015a72f2eab10c110f44a0e7c65543c657efd82602c1582e939dad4R18-R24)
* [`tests/packaged_modules/test_biodata.py`](diffhunk://#diff-9ecf032a3015a72f2eab10c110f44a0e7c65543c657efd82602c1582e939dad4L1077-R1155): Re-enabled and added multiple test cases to cover scenarios with multiple files and various label configurations, including positive and negative labels.