### PR TITLE
Multi process schema inference

### DIFF
--- a/src/biosets/download/__init__.py
+++ b/src/biosets/download/__init__.py
@@ -1,0 +1,1 @@
+from .schema_manager import SchemaManager

--- a/src/biosets/download/__init__.py
+++ b/src/biosets/download/__init__.py
@@ -1,1 +1,2 @@
+# ruff: noqa
 from .schema_manager import SchemaManager

--- a/src/biosets/download/schema_manager.py
+++ b/src/biosets/download/schema_manager.py
@@ -102,13 +102,21 @@ class SchemaManager(DownloadManager):
         elif file.endswith(".arrow") or file.endswith(".feather"):
             with open(file, "rb") as f:
                 return Features.from_arrow_schema(pa.ipc.read_schema(f))
-        elif file.endswith(".csv") and is_polars_available():
-            import polars as pl
+        elif is_polars_available():
+            if file.endswith(".csv"):
+                import polars as pl
 
-            schema = pl.scan_csv(file).collect_schema()
+                schema = pl.scan_csv(file).collect_schema()
 
-            schema = pl.DataFrame(schema=schema).to_arrow().schema
-            return Features.from_arrow_schema(schema)
+                schema = pl.DataFrame(schema=schema).to_arrow().schema
+                return Features.from_arrow_schema(schema)
+            elif file.endswith(".tsv") or file.endswith(".txt"):
+                import polars as pl
+
+                schema = pl.scan_csv(file, separator="\t").collect_schema()
+
+                schema = pl.DataFrame(schema=schema).to_arrow().schema
+                return Features.from_arrow_schema(schema)
 
     def _download_single(
         self, url_or_filename: str, download_config: DownloadConfig, get_schema=False

--- a/src/biosets/download/schema_manager.py
+++ b/src/biosets/download/schema_manager.py
@@ -1,0 +1,116 @@
+import multiprocessing
+import os
+from functools import partial
+from typing import List
+
+import datasets.config
+import fsspec
+import pyarrow as pa
+import pyarrow.parquet as pq
+from biocore.utils.import_util import is_polars_available
+from biocore.utils.inspect import get_kwargs
+from datasets.download.download_config import DownloadConfig
+from datasets.download.download_manager import DownloadManager
+from datasets.features.features import Features
+from datasets.utils.file_utils import is_relative_path, url_or_path_join, url_to_fs
+from datasets.utils.logging import tqdm
+from tqdm.contrib.concurrent import thread_map
+
+
+class SchemaManager(DownloadManager):
+    @classmethod
+    def from_dl_manager(cls, dl_manager: DownloadManager) -> "SchemaManager":
+        kwargs = dl_manager.__dict__.copy()
+        init_kwargs = get_kwargs(kwargs, dl_manager.__init__)
+        cls_instance = cls(**init_kwargs)
+        for k, v in kwargs.items():
+            if k not in init_kwargs:
+                setattr(cls_instance, k, v)
+        return cls_instance
+
+    def _download_batched(
+        self,
+        url_or_filenames: List[str],
+        download_config: DownloadConfig,
+    ) -> List[str]:
+        """
+        Adapted from datasets.download.download_manager.DownloadManager._download_batched
+        with the addition of schema gathering.
+        """
+        if len(url_or_filenames) >= 16:
+            download_config = download_config.copy()
+            download_config.disable_tqdm = True
+            download_func = partial(
+                self._download_single, download_config=download_config, get_schema=True
+            )
+
+            fs: fsspec.AbstractFileSystem
+            path = str(url_or_filenames[0])
+            if is_relative_path(path):
+                # append the relative path to the base_path
+                path = url_or_path_join(self._base_path, path)
+            fs, path = url_to_fs(path, **download_config.storage_options)
+            size = 0
+            try:
+                size = fs.info(path).get("size", 0)
+            except Exception:
+                pass
+            max_workers = (
+                datasets.config.HF_DATASETS_MULTITHREADING_MAX_WORKERS
+                if size < (20 << 20)
+                else 1
+            )  # enable multithreading if files are small
+
+            out = thread_map(
+                download_func,
+                url_or_filenames,
+                desc=download_config.download_desc
+                or "Downloading files and gathering schema",
+                unit="files",
+                position=multiprocessing.current_process()._identity[
+                    -1
+                ]  # contains the ranks of subprocesses
+                if os.environ.get(
+                    "HF_DATASETS_STACK_MULTIPROCESSING_DOWNLOAD_PROGRESS_BARS"
+                )
+                == "1"
+                and multiprocessing.current_process()._identity
+                else None,
+                max_workers=max_workers,
+                tqdm_class=tqdm,
+            )
+        else:
+            out = [
+                self._download_single(
+                    url_or_filename, download_config=download_config, get_schema=True
+                )
+                for url_or_filename in url_or_filenames
+            ]
+        files, features = zip(*out)
+        self.features = {}
+        for feature in features:
+            self.features.update(feature)
+        return list(files)
+
+    def _gather_schema(self, file):
+        if file.endswith(".parquet") or file.endswith(".pq"):
+            with open(file, "rb") as f:
+                return Features.from_arrow_schema(pq.read_schema(f))
+        elif file.endswith(".arrow") or file.endswith(".feather"):
+            with open(file, "rb") as f:
+                return Features.from_arrow_schema(pa.ipc.read_schema(f))
+        elif file.endswith(".csv") and is_polars_available():
+            import polars as pl
+
+            schema = pl.scan_csv(file).collect_schema()
+
+            schema = pl.DataFrame(schema=schema).to_arrow().schema
+            return Features.from_arrow_schema(schema)
+
+    def _download_single(
+        self, url_or_filename: str, download_config: DownloadConfig, get_schema=False
+    ) -> str:
+        out = super()._download_single(url_or_filename, download_config)
+        if get_schema:
+            return out, self._gather_schema(out)
+        return out

--- a/src/biosets/download/schema_manager.py
+++ b/src/biosets/download/schema_manager.py
@@ -89,7 +89,10 @@ class SchemaManager(DownloadManager):
         files, features = zip(*out)
         self.features = {}
         for feature in features:
-            self.features.update(feature)
+            if feature is not None:
+                self.features.update(feature)
+        if len(self.features) == 0:
+            self.features = None
         return list(files)
 
     def _gather_schema(self, file):

--- a/src/biosets/load.py
+++ b/src/biosets/load.py
@@ -159,22 +159,46 @@ def load_dataset(*args, **kwargs):
             load_dataset_builder.__init__
         ).parameters.keys()
         matching_args = set(dataset_builder_args).intersection(load_dataset_args)
-        new_kwargs.update({k: getattr(dataset_builder, k) for k in matching_args})
+        new_kwargs.update(
+            {
+                k: getattr(dataset_builder, k)
+                for k in matching_args
+                if k not in existing_kwargs
+            }
+        )
 
         builder_config = dataset_builder.config
         builder_config_args = inspect.signature(
             builder_config.__init__
         ).parameters.keys()
         matching_args = set(builder_config_args).intersection(load_dataset_args)
-        new_kwargs.update({k: getattr(builder_config, k) for k in matching_args})
+        new_kwargs.update(
+            {
+                k: getattr(builder_config, k)
+                for k in matching_args
+                if k not in existing_kwargs
+            }
+        )
 
         builder_info = dataset_builder.info
         builder_info_args = inspect.signature(builder_info.__init__).parameters.keys()
         matching_args = set(builder_info_args).intersection(load_dataset_args)
-        new_kwargs.update({k: getattr(builder_info, k) for k in matching_args})
+        new_kwargs.update(
+            {
+                k: getattr(builder_info, k)
+                for k in matching_args
+                if k not in existing_kwargs
+            }
+        )
 
         experiment_type = new_kwargs.pop("experiment_type", "biodata")
         new_kwargs["module_path"] = inspect.getfile(dataset_builder.__class__)
+
+        if not dataset_builder.__module__.startswith("biosets") and kwargs.get(
+            "add_missing_columns", False
+        ):
+            new_kwargs["features"] = None
+
         return load_dataset(
             **new_kwargs,
             experiment_type=experiment_type,

--- a/src/biosets/load.py
+++ b/src/biosets/load.py
@@ -214,6 +214,13 @@ def load_dataset(*args, **kwargs):
                 if k not in existing_kwargs
             }
         )
+        builder_kwargs.update(
+            {
+                k: new_kwargs.pop(k, None) or getattr(builder_info, k)
+                for k in builder_info_args
+                if k not in matching_args
+            }
+        )
 
         experiment_type = new_kwargs.pop("experiment_type", "biodata")
         new_kwargs["module_path"] = inspect.getfile(dataset_builder.__class__)

--- a/src/biosets/load.py
+++ b/src/biosets/load.py
@@ -170,11 +170,21 @@ def load_dataset(*args, **kwargs):
                 if k not in existing_kwargs
             }
         )
+        builder_kwargs.update(
+            {
+                k: new_kwargs.pop(k, None) or getattr(dataset_builder, k)
+                for k in dataset_builder_args
+                if k not in existing_kwargs
+                and k not in matching_args
+                and k not in ["args", "kwargs"]
+            }
+        )
 
         builder_config = dataset_builder.config
-        builder_config_args = inspect.signature(
-            builder_config.__init__
-        ).parameters.keys()
+        builder_config_args = inspect.signature(builder_config.__init__).parameters
+        builder_config_args = [
+            p.name for p in builder_config_args.values() if p != p.VAR_KEYWORD
+        ]
         matching_args = set(builder_config_args).intersection(load_dataset_args)
         new_kwargs.update(
             {

--- a/src/biosets/load.py
+++ b/src/biosets/load.py
@@ -149,6 +149,7 @@ def load_dataset(*args, **kwargs):
         path in EXPERIMENT_TYPE_ALIAS.keys()
         or path in EXPERIMENT_TYPE_TO_BUILDER_CLASS.keys()
     ):
+        existing_kwargs = kwargs.keys()
         path, new_kwargs = prepare_load_dataset(path, **kwargs)
         load_dataset_builder_kwargs = get_kwargs(kwargs, load_dataset_builder)
 

--- a/src/biosets/load.py
+++ b/src/biosets/load.py
@@ -230,6 +230,7 @@ def load_dataset(*args, **kwargs):
         ):
             new_kwargs["features"] = None
 
+        new_kwargs["builder_kwargs"] = builder_kwargs
         return load_dataset(
             **new_kwargs,
             experiment_type=experiment_type,

--- a/src/biosets/load.py
+++ b/src/biosets/load.py
@@ -157,8 +157,12 @@ def load_dataset(*args, **kwargs):
             dataset_builder = load_dataset_builder(path, **load_dataset_builder_kwargs)
         dataset_builder_args = inspect.signature(
             load_dataset_builder.__init__
-        ).parameters.keys()
+        ).parameters
+        dataset_builder_args = [
+            p.name for p in dataset_builder_args.values() if p != p.VAR_KEYWORD
+        ]
         matching_args = set(dataset_builder_args).intersection(load_dataset_args)
+        builder_kwargs = kwargs.get("builder_kwargs", {})
         new_kwargs.update(
             {
                 k: getattr(dataset_builder, k)

--- a/src/biosets/load.py
+++ b/src/biosets/load.py
@@ -193,9 +193,19 @@ def load_dataset(*args, **kwargs):
                 if k not in existing_kwargs
             }
         )
+        builder_kwargs.update(
+            {
+                k: new_kwargs.pop(k, None) or getattr(builder_config, k)
+                for k in builder_config_args
+                if k not in matching_args
+            }
+        )
 
         builder_info = dataset_builder.info
-        builder_info_args = inspect.signature(builder_info.__init__).parameters.keys()
+        builder_info_args = inspect.signature(builder_info.__init__).parameters
+        builder_info_args = [
+            p.name for p in builder_info_args.values() if p != p.VAR_KEYWORD
+        ]
         matching_args = set(builder_info_args).intersection(load_dataset_args)
         new_kwargs.update(
             {

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -59,7 +59,7 @@ logger = logging.get_logger(__name__)
 SAMPLE_COLUMN = "samples"
 BATCH_COLUMN = "batches"
 METADATA_COLUMN = "metadata"
-TARGET_COLUMN = "labels"
+TARGET_COLUMN = "encoded_labels"
 FEATURE_COLUMN = "features"
 DTYPE_MAP = {
     "double": "float32",

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -1348,32 +1348,9 @@ class BioData(datasets.ArrowBasedBuilder):
                                 v.id = self.config.target_column
                                 new_schema[self.TARGET_COLUMN] = v
 
-                    elif is_regression_type(v.pa_type):
-                        new_schema[self.TARGET_COLUMN] = RegressionTarget(
-                            v.dtype, id=self.config.target_column
-                        )
-                    elif self.config.labels and is_classification_type(v.pa_type):
-                        if self.config.positive_labels or self.config.negative_labels:
-                            new_schema[self.TARGET_COLUMN] = BinClassLabel(
-                                positive_labels=self.config.positive_labels,
-                                negative_labels=self.config.negative_labels,
-                                names=self.config.labels,
-                                id=self.config.target_column,
-                            )
-                        else:
-                            new_schema[self.TARGET_COLUMN] = ClassLabel(
-                                num_classes=len(self.config.labels),
-                                names=self.config.labels,
-                                id=self.config.target_column,
-                            )
                     else:
-                        raise ValueError(
-                            "The dataset seems to be a classification task, but the labels are not provided.\n"
-                            "Please provide the labels in the `labels` argument. For example:\n"
-                            "   >>> dataset = dataset.load_dataset('csv', data_files='data.csv', labels=[0, 1, 2])\n"
-                            "Or provide a sample metadata table with the labels column. For example:\n"
-                            "   >>> # metadata.csv contains a column named 'disease state' with labels 0, 1, 2\n"
-                            "   >>> dataset.load_dataset('csv', data_files='data.csv', sample_metadata_files='metadata.csv', target_column='disease state')\n"
+                        new_schema = self._create_target_feature(
+                            new_schema, v.pa_type, return_error=True
                         )
                 elif k == self.METADATA_COLUMN and isinstance(v, dict):
                     new_schema[self.METADATA_COLUMN] = Metadata(feature=v)

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -894,7 +894,7 @@ class BioData(datasets.ArrowBasedBuilder):
 
         return tbl
 
-    def _add_sample_metadata(self, table, sample_metadata=None):
+    def _add_sample_metadata(self, table, data_generator, sample_metadata=None):
         if self.config.sample_metadata_files:
             if self.config.sample_column in table.column_names:
                 colliding_names = list(
@@ -933,6 +933,16 @@ class BioData(datasets.ArrowBasedBuilder):
                         .to_arrow()
                     )
             else:
+                table_dim = DataHandler.get_shape(table)
+                sample_metadata_dim = DataHandler.get_shape(sample_metadata)
+                if table_dim[0] != sample_metadata_dim[0]:
+                    raise ValueError(
+                        "No sample column found in the data table and the number of "
+                        "rows in the sample metadata table does not match the number "
+                        "of rows in the data table. Please provide a sample column in "
+                        "the data table or ensure that the number of rows in the sample "
+                        "metadata table matches the number of rows in the data table."
+                    )
                 # we are gonna assume that the row order in metadata is the same as the data
                 colliding_names = list(
                     (set(table.column_names) & set(sample_metadata.columns))

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -1298,8 +1298,8 @@ class BioData(datasets.ArrowBasedBuilder):
             new_schema={},
         ):
             for k, v in _schema.items():
-                if self.info.features:
-                    v_ = self.info.features.get(k, None)
+                if self.config.features:
+                    v_ = self.config.features.get(k, None)
                     if v_:
                         new_schema[k] = v_
                         continue

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -1074,7 +1074,11 @@ class BioData(datasets.ArrowBasedBuilder):
             stored_metadata_schema = table.schema.metadata or {}
 
             sample_metadata = self._load_metadata(
-                file_index, sample_metadata, split_name=split_name
+                table,
+                key,
+                sample_metadata_generator_iter,
+                sample_metadata,
+                split_name=split_name,
             )
             if check_columns:
                 features = table.column_names
@@ -1119,7 +1123,7 @@ class BioData(datasets.ArrowBasedBuilder):
                         "of columns in the data table. Ignoring feature metadata."
                     )
 
-            table = self._add_sample_metadata(table, sample_metadata)
+            table = self._add_sample_metadata(table, generator, sample_metadata)
             table = self._prepare_labels(table, sample_metadata, split_name=split_name)
             # table = self._prepare_data(table)
             metadata_schema = None

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -168,16 +168,12 @@ class BioDataConfig(datasets.BuilderConfig):
     feature_column: Optional[str] = None
     columns: Optional[List[str]] = None
 
-    drop_labels: bool = None
-    drop_samples: bool = None
-    drop_batches: bool = None
-    drop_metadata: bool = None
-    drop_feature_metadata: bool = None
+    encode_labels: bool = None
 
     builder_kwargs: dict = None
-    data_kwargs: dict = None
-    metadata_kwargs: dict = None
-    feature_metadata_kwargs: dict = None
+    data_builder_kwargs: dict = None
+    sample_metadata_builder_kwargs: dict = None
+    feature_metadata_builder_kwargs: dict = None
 
     use_polars: bool = True
 

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -1197,7 +1197,9 @@ class BioData(datasets.ArrowBasedBuilder):
             file_index += 1
             yield key, table
 
-    def _load_metadata(self, file_index, sample_metadata=None, split_name=None):
+    def _load_metadata(
+        self, table, file_key, gen_table_iter, sample_metadata=None, split_name=None
+    ):
         if self.config.sample_metadata_files:
             if not isinstance(self.config.sample_metadata_files, DataFilesDict):
                 raise ValueError(
@@ -1207,40 +1209,59 @@ class BioData(datasets.ArrowBasedBuilder):
                 return None
 
             files = self.config.sample_metadata_files[split_name]
-            if len(files) == 1:
-                if file_index != 0:
+            if len(files) == 1 and sample_metadata is not None:
+                return sample_metadata
+
+            if len(files) > 1 and len(self.config.data_files[split_name]) == 1:
+                # Load the entire metadata table if only one data file is provided
+                if sample_metadata is not None:
                     return sample_metadata
-            # only use file_index if data files are sharded
-            elif len(self.config.data_files[split_name]) > 1:
-                files = [files[file_index]]
+                tables = []
+                total_rows = 0
+                out = next(gen_table_iter)
+                while out is not None:
+                    _, row = out
+                    total_rows += row.num_rows
+                    tables.append(row)
+                    out = next(gen_table_iter, None)
+                sample_metadata = pa.concat_tables(tables, promote_options="default")
+                return DataHandler.to_pandas(sample_metadata)
 
-            sample_metadata = self._read_metadata(files, to_arrow=False)
-            # TODO: temporary fix for not getting a pandas DataFrame
-            if isinstance(sample_metadata, pa.Table):
-                sample_metadata = DataHandler.to_pandas(sample_metadata)
-            return sample_metadata
+            sample_metadata = next(gen_table_iter)[1]
+            return DataHandler.to_pandas(sample_metadata)
 
-    def _read_metadata(self, metadata_files, use_polars: bool = True, to_arrow=True):
-        if not metadata_files:
-            raise ValueError("Empty list of metadata files provided.")
-
-        metadata_ext = os.path.splitext(metadata_files[0])[-1][1:]
-
-        if "json" in metadata_ext:
-            metadata_ext = "json"
-
-        dataset = next(
-            iter(
-                datasets.load_dataset(
-                    metadata_ext,
-                    data_files=metadata_files,
-                    cache_dir=self._cache_dir_root,
-                ).values()
+    def _create_target_feature(
+        self, schema: dict, dtype: pa.DataType, return_error=True
+    ):
+        if self.config.labels and is_classification_type(dtype):
+            if self.config.positive_labels or self.config.negative_labels:
+                schema[self.TARGET_COLUMN] = BinClassLabel(
+                    positive_labels=self.config.positive_labels,
+                    negative_labels=self.config.negative_labels,
+                    names=self.config.labels,
+                    id=self.config.target_column,
+                )
+            else:
+                schema[self.TARGET_COLUMN] = ClassLabel(
+                    num_classes=len(self.config.labels),
+                    names=self.config.labels,
+                    id=self.config.target_column,
+                )
+        elif is_regression_type(dtype):
+            schema[self.TARGET_COLUMN] = RegressionTarget(
+                dtype.dtype, id=self.config.target_column
             )
-        )
-        if to_arrow:
-            return dataset._data.table
-        return dataset.to_pandas()
+        elif return_error:
+            raise ValueError(
+                "The dataset seems to be a classification task, but the labels are not provided.\n"
+                "Please provide the labels in the `labels` argument. For example:\n"
+                "   >>> dataset = dataset.load_dataset('csv', data_files='data.csv', labels=[0, 1, 2])\n"
+                "Or provide a sample metadata table with the labels column. For example:\n"
+                "   >>> # metadata.csv contains a column named 'disease state' with labels 0, 1, 2\n"
+                "   >>> dataset.load_dataset('csv', data_files='data.csv', sample_metadata_files='metadata.csv', target_column='disease state')\n"
+            )
+
+        return schema
 
     def _create_features(
         self,

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -26,7 +26,9 @@ from datasets.packaged_modules.arrow import arrow as hf_arrow
 from datasets.packaged_modules.csv import csv as hf_csv
 from datasets.packaged_modules.json import json as hf_json
 from datasets.packaged_modules.parquet import parquet as hf_parquet
-from datasets.utils.py_utils import asdict, tqdm
+from datasets.utils import tqdm as hf_tqdm
+from datasets.utils.py_utils import asdict
+from tqdm.contrib.concurrent import thread_map
 
 from biosets.data_files import (
     FEATURE_METADATA_PATTERNS,

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -585,6 +585,7 @@ class BioData(datasets.ArrowBasedBuilder):
     _drop_columns = set()
     _all_columns = set()
     _label_map: dict = None
+    _missing_label_value = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -784,18 +785,26 @@ class BioData(datasets.ArrowBasedBuilder):
                     else:
                         self.config.labels.append("positive")
 
+                if self._missing_label_value is None:
+                    self._missing_label_value = -1
                 if not self._label_map:
                     self._label_map = {}
                     if self.config.positive_labels:
                         self._label_map.update(
                             {label: 1 for label in self.config.positive_labels}
                         )
+                        self._missing_label_value = 0
                     if self.config.negative_labels:
                         self._label_map.update(
                             {label: 0 for label in self.config.negative_labels}
                         )
+                        self._missing_label_value = 1
+
+                    if self.config.positive_labels and self.config.negative_labels:
+                        self._missing_label_value = -1
+
                 bin_labels = [
-                    self._label_map.get(label, -1)
+                    self._label_map.get(label, self._missing_label_value)
                     for label in DataHandler.to_list(
                         DataHandler.select_column(tbl, self.config.target_column)
                     )

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -11,7 +11,6 @@ import datasets
 import pandas as pd
 import pandas.api.types as pdt
 import pyarrow as pa
-import pyarrow.parquet as pq
 from biocore.data_handling import DataHandler
 from biocore.utils.import_util import is_polars_available
 from datasets.data_files import (
@@ -26,9 +25,7 @@ from datasets.packaged_modules.arrow import arrow as hf_arrow
 from datasets.packaged_modules.csv import csv as hf_csv
 from datasets.packaged_modules.json import json as hf_json
 from datasets.packaged_modules.parquet import parquet as hf_parquet
-from datasets.utils import tqdm as hf_tqdm
 from datasets.utils.py_utils import asdict
-from tqdm.contrib.concurrent import thread_map
 
 from biosets.data_files import (
     FEATURE_METADATA_PATTERNS,

--- a/src/biosets/packaged_modules/biodata/biodata.py
+++ b/src/biosets/packaged_modules/biodata/biodata.py
@@ -122,14 +122,14 @@ class InvalidPath(Exception):
 
 
 SAMPLE_COLUMN_WARN_MSG = (
-    "Could not find the sample column in the sample metadata table.\n"
+    "\nCould not find the sample column in the sample metadata table.\n"
     "Please provide the sample column by setting the `sample_column` argument. For example:\n"
     "   >>> `load_dataset(..., sample_column='samples')`.\n"
     "Sample metadata will be ignored."
 )
 
 FEATURE_COLUMN_WARN_MSG = (
-    "Could not find the feature column in the feature metadata table.\n"
+    "\nCould not find the feature column in the feature metadata table.\n"
     "Please provide the feature column by setting the `feature_column` argument. For example:\n"
     "   >>> `load_dataset(..., feature_column='my_feature_column')`.\n"
     "Feature metadata will be ignored."
@@ -217,8 +217,10 @@ class BioDataConfig(datasets.BuilderConfig):
         # Check for invalid characters in the config name
         if any(char in self.name for char in INVALID_WINDOWS_CHARACTERS_IN_PATH):
             raise datasets.builder.InvalidConfigName(
-                f"Bad characters from black list '{INVALID_WINDOWS_CHARACTERS_IN_PATH}' found in '{self.name}'. "
-                f"They could create issues when creating a directory for this config on Windows filesystem."
+                "Bad characters from black list "
+                f"'{INVALID_WINDOWS_CHARACTERS_IN_PATH}' found in '{self.name}'. "
+                "They could create issues when creating a directory for this config "
+                "on Windows filesystem."
             )
 
         # Validate and process data_files
@@ -611,7 +613,7 @@ class BioData(datasets.ArrowBasedBuilder):
             # since the metadata columns were specified, we notify the user of any columns that were not found
             if not_found_cols:
                 logger.warning_once(
-                    f"Could not find the following metadata columns in the table: {not_found_cols}"
+                    f"\nCould not find the following metadata columns in the table: {not_found_cols}"
                 )
 
         # gather the sample metadata columns if not already specified
@@ -649,7 +651,7 @@ class BioData(datasets.ArrowBasedBuilder):
                 ) - set(data_features)
                 if missing_columns:
                     logger.warning_once(
-                        f"Could not find the following columns in the data table: {missing_columns}"
+                        f"\nCould not find the following columns in the data table: {missing_columns}"
                     )
             else:
                 logger.warning_once(FEATURE_COLUMN_WARN_MSG)
@@ -976,7 +978,7 @@ class BioData(datasets.ArrowBasedBuilder):
                 table_dims = DataHandler.get_shape(table)
                 if feature_metadata_dims[0] == table_dims[1]:
                     logger.warning_once(
-                        "No data columns were provided, but the number of columns "
+                        "\nNo data columns were provided, but the number of columns "
                         "in the data table matches the number of features in the "
                         "feature metadata. Using feature metadata as column names."
                     )
@@ -989,7 +991,7 @@ class BioData(datasets.ArrowBasedBuilder):
                     table = DataHandler.set_column_names(table, features)
                 else:
                     logger.warning_once(
-                        "Feature metadata was provided along with an npz file, but the "
+                        "\nFeature metadata was provided along with an npz file, but the "
                         "number of features in the metadata does not match the number "
                         "of columns in the data table. Ignoring feature metadata."
                     )
@@ -1354,12 +1356,12 @@ def _infer_column_name(
     if column_name:
         if name_in_features and not name_in_metadata:
             logger.warning_once(
-                f"'{column_name}' was found in the data table but not in the metadata table.\n"
+                f"\n'{column_name}' was found in the data table but not in the metadata table.\n"
                 f"Please add or rename the column in the metadata table.\n"
             )
         elif not name_in_features and name_in_metadata:
             logger.warning_once(
-                f"'{column_name}' was found in the metadata table but not in the data table.\n"
+                f"\n'{column_name}' was found in the metadata table but not in the data table.\n"
                 f"Please add or rename the column in the data table.\n"
             )
         else:
@@ -1433,7 +1435,7 @@ def _infer_column_name(
                     logger.debug(f"Pattern match found: {dcol} -> {col}")
         if other_possible_col:
             logger.warning_once(
-                f"Two possible matches found for the {default_column_name} column:\n"
+                f"\nTwo possible matches found for the {default_column_name} column:\n"
                 f"1. '{possible_col}' in {which_table} table\n"
                 f"2. '{other_possible_col}' in {other_table} table\n"
                 "Please rename the columns or provide the `sample_column` argument to "
@@ -1443,7 +1445,7 @@ def _infer_column_name(
             )
         else:
             logger.warning_once(
-                f"A match for the {default_column_name} column was found in "
+                f"\nA match for the {default_column_name} column was found in "
                 f"{which_table} table: '{possible_col}'\n"
                 f"But it was not found in {other_table} table.\n"
                 "Please add or rename the column in the appropriate table.\n"
@@ -1462,7 +1464,7 @@ def _infer_column_name(
         raise _COLUMN_TO_ERROR[default_column_name](err_msg)
 
     logger.warning_once(
-        f"Could not find the {default_column_name} column in " + generate_err_msg()
+        f"\nCould not find the {default_column_name} column in " + generate_err_msg()
     )
     return None
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,12 +1,68 @@
-import textwrap
 import os
+import textwrap
 
 import pyarrow as pa
 import pytest
+from biosets import load_dataset
 from datasets import Features, Value
 from datasets.arrow_writer import ArrowWriter
+from datasets.exceptions import DatasetGenerationError
 
-from biosets import load_dataset
+from biosets.packaged_modules.biodata.biodata import TARGET_COLUMN
+
+
+@pytest.fixture
+def npz_file(tmp_path):
+    import scipy.sparse as sp
+
+    filename = tmp_path / "file.npz"
+
+    n_samples = 3
+    n_features = 2
+
+    data = sp.csr_matrix(
+        sp.random(
+            n_samples,
+            n_features,
+            density=0.5,
+            format="csr",
+            random_state=42,
+        )
+    )
+    sp.save_npz(filename, data)
+    return str(filename)
+
+
+@pytest.fixture
+def data_with_metadata(tmp_path):
+    filename = tmp_path / "data_with_metadata.csv"
+    data = textwrap.dedent(
+        """
+        sample,metadata1,metadata2,header1,header2,target
+        sample1,a,1,1,10,a
+        sample2,b,20,20,2,b
+        sample3,c,3,3,30,c
+        """
+    )
+    with open(filename, "w") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def feature_metadata_file(tmp_path):
+    filename = tmp_path / "feature_metadata.csv"
+    data = textwrap.dedent(
+        """
+        feature,metadata1,metadata2
+        header1,a,1
+        header2,b,20
+        header3,c,3
+        """
+    )
+    with open(filename, "w") as f:
+        f.write(data)
+    return str(filename)
 
 
 @pytest.fixture
@@ -38,6 +94,72 @@ def data_dir_with_arrow(tmp_path):
     assert num_examples == 10
     assert num_bytes > 0
     return str(data_dir)
+
+
+@pytest.fixture
+def sample_metadata_file(tmp_path):
+    filename = tmp_path / "sample_metadata.csv"
+    data = textwrap.dedent(
+        """
+        sample,batch,metadata1,metadata2,target
+        sample1,batch1,a,1,a
+        sample2,batch2,b,20,b
+        sample3,batch3,c,3,c
+        """
+    )
+    with open(filename, "w") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def sample_metadata_file_2(tmp_path):
+    filename = tmp_path / "sample_metadata_2.csv"
+    data = textwrap.dedent(
+        """
+        sample,batch,metadata1,metadata2,target
+        sample4,batch4,d,40,d
+        sample5,batch5,e,5,e
+        sample6,batch6,f,60,f
+        sample7,batch7,g,7,g
+        """
+    )
+    with open(filename, "w") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def data_with_samples(tmp_path):
+    filename = tmp_path / "data_with_samples.csv"
+    data = textwrap.dedent(
+        """
+        sample,header1,header2
+        sample1,1,10
+        sample2,20,2
+        sample3,3,30
+        """
+    )
+    with open(filename, "w") as f:
+        f.write(data)
+    return str(filename)
+
+
+@pytest.fixture
+def data_with_samples_2(tmp_path):
+    filename = tmp_path / "data_with_samples_2.csv"
+    data = textwrap.dedent(
+        """
+        sample,header1,header2
+        sample4,40,4
+        sample5,5,50
+        sample6,60,6
+        sample7,7,70
+        """
+    )
+    with open(filename, "w") as f:
+        f.write(data)
+    return str(filename)
 
 
 @pytest.fixture
@@ -183,6 +305,373 @@ def data_dir_biodata_with_split_names(tmp_path):
     return str(data_dir)
 
 
+def _create_unevenly_distributed_samples(data_dir):
+    filename = data_dir / "samples_train_1.csv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample,batch,metadata1,metadata2,target
+                sample1,batch1,a,2,a
+                sample2,batch2,b,20,b
+                """
+            )
+        )
+
+    filename = data_dir / "samples_train_2.csv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample,batch,metadata1,metadata2,target
+                sample3,batch3,c,3,c
+                sample4,batch4,d,40,d
+                """
+            )
+        )
+
+    filename = data_dir / "samples_test_1.csv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample,batch,metadata1,metadata2,target
+                sample5,batch5,e,5,e
+                sample6,batch6,f,60,f
+                """
+            )
+        )
+
+    filename = data_dir / "samples_test_2.csv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample,batch,metadata1,metadata2,target
+                sample7,batch7,g,7,g
+                sample8,batch8,h,80,h
+                """
+            )
+        )
+
+    filename = data_dir / "samples_test_3.csv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample,batch,metadata1,metadata2,target
+                sample9,batch9,i,9,i
+                sample10,batch10,j,100,j
+                """
+            )
+        )
+
+
+@pytest.fixture
+def data_dir_biodata_with_mismatched_shards_arrow(tmp_path):
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir()
+
+    _create_unevenly_distributed_samples(data_dir)
+
+    filename = data_dir / "features_1.jsonl"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """\
+                {"feature": "header1", "metadata1": "a", "metadata2": 2}
+                {"feature": "header2", "metadata1": "b", "metadata2": 20}
+                """
+            )
+        )
+
+    filename = data_dir / "features_2.jsonl"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """\
+                {"feature": "header3", "metadata1": "a", "metadata2": 2}
+                {"feature": "header4", "metadata1": "b", "metadata2": 20}
+                """
+            )
+        )
+
+    filename = data_dir / "features_3.jsonl"
+
+    output_train = os.path.join(data_dir, "data_train_1.arrow")
+    with ArrowWriter(path=output_train) as writer:
+        writer.write_table(
+            pa.Table.from_pydict({"header1": [1, 10], "header2": [2, 20]})
+        )
+        num_examples, num_bytes = writer.finalize()
+    assert num_examples == 2
+    assert num_bytes > 0
+    output_test = os.path.join(data_dir, "data_train_2.arrow")
+    with ArrowWriter(path=output_test) as writer:
+        writer.write_table(
+            pa.Table.from_pydict({"header3": [3, 30], "header4": [4, 40]})
+        )
+        num_examples, num_bytes = writer.finalize()
+    assert num_examples == 2
+    assert num_bytes > 0
+    output_test = os.path.join(data_dir, "data_test_1.arrow")
+    with ArrowWriter(path=output_test) as writer:
+        writer.write_table(
+            pa.Table.from_pydict({"header1": [5, 50], "header2": [6, 60]})
+        )
+        num_examples, num_bytes = writer.finalize()
+
+    assert num_examples == 2
+    assert num_bytes > 0
+    output_test = os.path.join(data_dir, "data_test_2.arrow")
+    with ArrowWriter(path=output_test) as writer:
+        writer.write_table(
+            pa.Table.from_pydict({"header3": [7, 70], "header4": [8, 80]})
+        )
+        num_examples, num_bytes = writer.finalize()
+    assert num_examples == 2
+    assert num_bytes > 0
+    output_test = os.path.join(data_dir, "data_test_3.arrow")
+    with ArrowWriter(path=output_test) as writer:
+        writer.write_table(
+            pa.Table.from_pydict({"header5": [9, 90], "header6": [10, 100]})
+        )
+        num_examples, num_bytes = writer.finalize()
+    assert num_examples == 2
+    assert num_bytes > 0
+
+    return str(data_dir)
+
+
+@pytest.fixture
+def data_dir_biodata_with_mismatched_shards_parquet(tmp_path):
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir()
+    _create_unevenly_distributed_samples(data_dir)
+
+    # filename = data_dir / "features_1.jsonl"
+    # with open(filename, "w") as f:
+    #     f.write(
+    #         textwrap.dedent(
+    #             """\
+    #             {"feature": "header1", "metadata1": "a", "metadata2": 2}
+    #             {"feature": "header2", "metadata1": "b", "metadata2": 20}
+    #             """
+    #         )
+    #     )
+    #
+    # filename = data_dir / "features_2.jsonl"
+    # with open(filename, "w") as f:
+    #     f.write(
+    #         textwrap.dedent(
+    #             """\
+    #             {"feature": "header3", "metadata1": "a", "metadata2": 2}
+    #             {"feature": "header4", "metadata1": "b", "metadata2": 20}
+    #             """
+    #         )
+    #     )
+
+    output_train = os.path.join(data_dir, "data_train_1.parquet")
+    table = pa.Table.from_pydict({"header1": [1, 10], "header2": [2, 20]})
+    pa.parquet.write_table(table, output_train)
+    output_test = os.path.join(data_dir, "data_train_2.parquet")
+    table = pa.Table.from_pydict({"header3": [3, 30], "header4": [4, 40]})
+    pa.parquet.write_table(table, output_test)
+    output_test = os.path.join(data_dir, "data_test_1.parquet")
+    table = pa.Table.from_pydict({"header1": [5, 50], "header2": [6, 60]})
+    pa.parquet.write_table(table, output_test)
+    output_test = os.path.join(data_dir, "data_test_2.parquet")
+    table = pa.Table.from_pydict({"header3": [7, 70], "header4": [8, 80]})
+    pa.parquet.write_table(table, output_test)
+    output_test = os.path.join(data_dir, "data_test_3.parquet")
+    table = pa.Table.from_pydict({"header5": [9, 90], "header6": [10, 100]})
+    pa.parquet.write_table(table, output_test)
+
+    return str(data_dir)
+
+
+@pytest.fixture
+def data_dir_biodata_with_mismatched_shards_csv(tmp_path):
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir()
+    _create_unevenly_distributed_samples(data_dir)
+
+    # filename = data_dir / "features_1.jsonl"
+    # with open(filename, "w") as f:
+    #     f.write(
+    #         textwrap.dedent(
+    #             """\
+    #             {"feature": "header1", "metadata1": "a", "metadata2": 2}
+    #             {"feature": "header2", "metadata1": "b", "metadata2": 20}
+    #             """
+    #         )
+    #     )
+    #
+    # filename = data_dir / "features_2.jsonl"
+    # with open(filename, "w") as f:
+    #     f.write(
+    #         textwrap.dedent(
+    #             """\
+    #             {"feature": "header3", "metadata1": "a", "metadata2": 2}
+    #             {"feature": "header4", "metadata1": "b", "metadata2": 20}
+    #             """
+    #         )
+    #     )
+
+    filename = data_dir / "data_train_1.csv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample,header1,header2
+                sample1,3,4
+                sample2,30,40
+                """
+            )
+        )
+
+    filename = data_dir / "data_train_2.csv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample,header3,header4
+                sample3,5,6
+                sample4,50,60
+                """
+            )
+        )
+
+    filename = data_dir / "data_test_1.csv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample,header1,header2
+                sample5,7,8
+                sample6,70,80
+                """
+            )
+        )
+
+    filename = data_dir / "data_test_2.csv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample,header3,header4
+                sample7,9,10
+                sample8,90,100
+                """
+            )
+        )
+
+    filename = data_dir / "data_test_3.csv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample,header5,header6
+                sample9,11,12
+                sample10,110,120
+                """
+            )
+        )
+
+    return str(data_dir)
+
+
+@pytest.fixture
+def data_dir_biodata_with_mismatched_shards_tsv(tmp_path):
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir()
+    _create_unevenly_distributed_samples(data_dir)
+
+    # filename = data_dir / "features_1.jsonl"
+    # with open(filename, "w") as f:
+    #     f.write(
+    #         textwrap.dedent(
+    #             """\
+    #             {"feature": "header1", "metadata1": "a", "metadata2": 2}
+    #             {"feature": "header2", "metadata1": "b", "metadata2": 20}
+    #             """
+    #         )
+    #     )
+    #
+    # filename = data_dir / "features_2.jsonl"
+    # with open(filename, "w") as f:
+    #     f.write(
+    #         textwrap.dedent(
+    #             """\
+    #             {"feature": "header3", "metadata1": "a", "metadata2": 2}
+    #             {"feature": "header4", "metadata1": "b", "metadata2": 20}
+    #             """
+    #         )
+    #     )
+
+    filename = data_dir / "data_train_1.tsv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample\theader1\theader2
+                sample1\t3\t4
+                sample2\t30\t40
+                """
+            )
+        )
+
+    filename = data_dir / "data_train_2.tsv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample\theader3\theader4
+                sample3\t5\t6
+                sample4\t50\t60
+                """
+            )
+        )
+
+    filename = data_dir / "data_test_1.tsv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample\theader1\theader2
+                sample5\t7\t8
+                sample6\t70\t80
+                """
+            )
+        )
+
+    filename = data_dir / "data_test_2.tsv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample\theader3\theader4
+                sample7\t9\t10
+                sample8\t90\t100
+                """
+            )
+        )
+
+    filename = data_dir / "data_test_3.tsv"
+    with open(filename, "w") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                sample\theader5\theader6
+                sample9\t11\t12
+                sample10\t110\t120
+                """
+            )
+        )
+
+    return str(data_dir)
+
+
 @pytest.fixture
 def data_dir_with_metadata(tmp_path):
     data_dir = tmp_path / "data_dir_with_metadata"
@@ -199,51 +688,6 @@ def data_dir_with_metadata(tmp_path):
         """
         )
     return str(data_dir)
-
-
-@pytest.fixture
-def sample_metadata_file_2(tmp_path):
-    filename = tmp_path / "sample_metadata_2.csv"
-    data = textwrap.dedent(
-        """
-        sample,batch,metadata1,metadata2,target
-        sample3,batch3,c,3,c
-        sample4,batch4,d,40,d
-        """
-    )
-    with open(filename, "w") as f:
-        f.write(data)
-    return str(filename)
-
-
-@pytest.fixture
-def data_with_samples(tmp_path):
-    filename = tmp_path / "data_with_samples.csv"
-    data = textwrap.dedent(
-        """
-        sample,header1,header2
-        sample1,1,2
-        sample2,10,20
-        """
-    )
-    with open(filename, "w") as f:
-        f.write(data)
-    return str(filename)
-
-
-@pytest.fixture
-def data_with_samples_2(tmp_path):
-    filename = tmp_path / "data_with_samples_2.csv"
-    data = textwrap.dedent(
-        """
-        sample,header1,header2
-        sample3,3,4
-        sample4,30,40
-        """
-    )
-    with open(filename, "w") as f:
-        f.write(data)
-    return str(filename)
 
 
 def test_load_dataset_with_dir(data_dir_biodata):
@@ -264,7 +708,7 @@ def test_load_dataset_with_dir(data_dir_biodata):
         "header2": 2,
         "header3": 3,
         "header4": 4,
-        "labels": 0,
+        TARGET_COLUMN: 0,
     }
 
 
@@ -283,7 +727,7 @@ def test_load_dataset_with_dir_and_split_names(data_dir_biodata_with_split_names
         "target": "a",
         "header1": 1,
         "header2": 2,
-        "labels": 0,
+        TARGET_COLUMN: 0,
     }
 
     ds_test_item = next(iter(ds["test"]))
@@ -295,8 +739,221 @@ def test_load_dataset_with_dir_and_split_names(data_dir_biodata_with_split_names
         "target": "c",
         "header1": 3,
         "header2": 4,
-        "labels": 2,
+        TARGET_COLUMN: 2,
     }
+
+
+@pytest.mark.parametrize("with_labels", [True, False])
+@pytest.mark.parametrize("encode_labels", [True, False])
+def test_load_dataset_with_dir_mismatched_shards_arrow(
+    data_dir_biodata_with_mismatched_shards_arrow,
+    with_labels,
+    encode_labels,
+):
+    if with_labels:
+        ds = load_dataset(
+            "arrow",
+            data_dir=data_dir_biodata_with_mismatched_shards_arrow,
+            labels=["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
+            encode_labels=encode_labels,
+            add_missing_columns=True,
+        )
+    else:
+        try:
+            ds = load_dataset(
+                "arrow",
+                data_dir=data_dir_biodata_with_mismatched_shards_arrow,
+                add_missing_columns=True,
+                encode_labels=encode_labels,
+            )
+        except DatasetGenerationError as e:
+            # ensure that the error before DatasetGenerationError is a ValueError
+            assert str(e.__cause__) == (
+                "Labels must be provided if multiple sample metadata files "
+                "are provided. Either set `labels`, `positive_labels` "
+                "and/or `negative_labels` in `load_dataset`."
+            )
+            return
+
+    ds_train_item = next(iter(ds["train"]))
+    assert ds["train"].shape[0] == 4
+    expected_train_item = {
+        "sample": "sample1",
+        "batch": "batch1",
+        "metadata1": "a",
+        "metadata2": 2,
+        "target": "a",
+        "header1": 1,
+        "header2": 2,
+        "header3": None,
+        "header4": None,
+        "header5": None,
+        "header6": None,
+    }
+    if encode_labels:
+        expected_train_item[TARGET_COLUMN] = 0
+    assert ds_train_item == expected_train_item
+
+    ds_test_item = next(iter(ds["test"]))
+    expected_test_item = {
+        "sample": "sample5",
+        "batch": "batch5",
+        "metadata1": "e",
+        "metadata2": 5,
+        "target": "e",
+        "header1": 5,
+        "header2": 6,
+        "header3": None,
+        "header4": None,
+        "header5": None,
+        "header6": None,
+    }
+    if encode_labels:
+        expected_test_item[TARGET_COLUMN] = 4
+    assert ds["test"].shape[0] == 6
+    assert ds_test_item == expected_test_item
+
+
+def test_load_dataset_with_dir_mismatched_shards_parquet(
+    data_dir_biodata_with_mismatched_shards_parquet,
+):
+    ds = load_dataset(
+        "parquet",
+        data_dir=data_dir_biodata_with_mismatched_shards_parquet,
+        labels=["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
+        add_missing_columns=True,
+    )
+
+    ds_train_item = next(iter(ds["train"]))
+    assert ds["train"].shape[0] == 4
+    expected_train_item = {
+        "sample": "sample1",
+        "batch": "batch1",
+        "metadata1": "a",
+        "metadata2": 2,
+        "target": "a",
+        "header1": 1,
+        "header2": 2,
+        "header3": None,
+        "header4": None,
+        "header5": None,
+        "header6": None,
+        TARGET_COLUMN: 0,
+    }
+    assert ds_train_item == expected_train_item
+
+    ds_test_item = next(iter(ds["test"]))
+    expected_test_item = {
+        "sample": "sample5",
+        "batch": "batch5",
+        "metadata1": "e",
+        "metadata2": 5,
+        "target": "e",
+        "header1": 5,
+        "header2": 6,
+        "header3": None,
+        "header4": None,
+        "header5": None,
+        "header6": None,
+        TARGET_COLUMN: 4,
+    }
+    assert ds["test"].shape[0] == 6
+    assert ds_test_item == expected_test_item
+
+
+def test_load_dataset_with_dir_mismatched_shards_csv(
+    data_dir_biodata_with_mismatched_shards_csv,
+):
+    ds = load_dataset(
+        "csv",
+        data_dir=data_dir_biodata_with_mismatched_shards_csv,
+        labels=["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
+        add_missing_columns=True,
+    )
+
+    ds_train_item = next(iter(ds["train"]))
+    assert ds["train"].shape[0] == 4
+    expected_train_item = {
+        "sample": "sample1",
+        "batch": "batch1",
+        "metadata1": "a",
+        "metadata2": 2,
+        "target": "a",
+        "header1": 3,
+        "header2": 4,
+        "header3": None,
+        "header4": None,
+        "header5": None,
+        "header6": None,
+        TARGET_COLUMN: 0,
+    }
+    assert ds_train_item == expected_train_item
+
+    ds_test_item = next(iter(ds["test"]))
+    expected_test_item = {
+        "sample": "sample5",
+        "batch": "batch5",
+        "metadata1": "e",
+        "metadata2": 5,
+        "target": "e",
+        "header1": 7,
+        "header2": 8,
+        "header3": None,
+        "header4": None,
+        "header5": None,
+        "header6": None,
+        TARGET_COLUMN: 4,
+    }
+    assert ds["test"].shape[0] == 6
+    assert ds_test_item == expected_test_item
+
+
+def test_load_dataset_with_dir_mismatched_shards_tsv(
+    data_dir_biodata_with_mismatched_shards_tsv,
+):
+    ds = load_dataset(
+        "csv",
+        sep="\t",
+        data_dir=data_dir_biodata_with_mismatched_shards_tsv,
+        labels=["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
+        add_missing_columns=True,
+    )
+
+    ds_train_item = next(iter(ds["train"]))
+    assert ds["train"].shape[0] == 4
+    expected_train_item = {
+        "sample": "sample1",
+        "batch": "batch1",
+        "metadata1": "a",
+        "metadata2": 2,
+        "target": "a",
+        "header1": 3,
+        "header2": 4,
+        "header3": None,
+        "header4": None,
+        "header5": None,
+        "header6": None,
+        TARGET_COLUMN: 0,
+    }
+    assert ds_train_item == expected_train_item
+
+    ds_test_item = next(iter(ds["test"]))
+    expected_test_item = {
+        "sample": "sample5",
+        "batch": "batch5",
+        "metadata1": "e",
+        "metadata2": 5,
+        "target": "e",
+        "header1": 7,
+        "header2": 8,
+        "header3": None,
+        "header4": None,
+        "header5": None,
+        "header6": None,
+        TARGET_COLUMN: 4,
+    }
+    assert ds["test"].shape[0] == 6
+    assert ds_test_item == expected_test_item
 
 
 @pytest.mark.parametrize("path_extension", ["csv", "csv.bz2"])
@@ -374,6 +1031,155 @@ def test_load_dataset_arrow(streaming, data_dir_with_arrow):
         assert ds.shape[0] == expected_size
         ds_item = next(iter(ds))
         assert ds_item == {"col_1": "foo"}
+
+
+def test_biodata_load_dataset_with_sparse_reader(
+    npz_file, sample_metadata_file, feature_metadata_file
+):
+    data = load_dataset(
+        "snp",
+        data_files=npz_file,
+        sample_metadata_files=sample_metadata_file,
+        feature_metadata_files=feature_metadata_file,
+        target_column="target",
+    )["train"]
+    pd_data = data.to_pandas()
+    assert pd_data["sample"].tolist() == ["sample1", "sample2", "sample3"]
+    assert pd_data["target"].tolist() == ["a", "b", "c"]
+    assert set(pd_data[TARGET_COLUMN].tolist()) == set([0, 1, 2])
+
+
+def test_biodata_load_dataset_with_multiple_files_and_without_labels(
+    data_with_metadata, sample_metadata_file, feature_metadata_file
+):
+    try:
+        load_dataset(
+            "snp",
+            data_files=[data_with_metadata, data_with_metadata],
+            sample_metadata_files=[
+                sample_metadata_file,
+                sample_metadata_file,
+            ],
+            feature_metadata_files=feature_metadata_file,
+            target_column="target",
+        )["train"]
+    except DatasetGenerationError as e:
+        assert (
+            "Labels must be provided if multiple sample metadata files "
+            "are provided. Either set `labels`, `positive_labels` "
+            "and/or `negative_labels` in `load_dataset`." in str(e.__cause__)
+        )
+
+    try:
+        load_dataset(
+            "snp",
+            data_files=[data_with_metadata, data_with_metadata],
+            feature_metadata_files=feature_metadata_file,
+            target_column="target",
+        )["train"]
+
+    except DatasetGenerationError as e:
+        assert (
+            "Labels must be provided if multiple data files "
+            "are provided and the target column is found in the "
+            "data table. Either set `labels`, `positive_labels` "
+            "and/or `negative_labels` in `load_dataset`." in str(e.__cause__)
+        )
+
+
+def test_biodata_load_dataset_with_multiple_files_and_with_labels(
+    data_with_metadata, feature_metadata_file
+):
+    data = load_dataset(
+        "snp",
+        data_files=[data_with_metadata, data_with_metadata],
+        feature_metadata_files=feature_metadata_file,
+        labels=["a", "b"],
+        target_column="target",
+    )["train"]
+    pd_data = data.to_pandas()
+    assert len(pd_data) == 6
+    assert pd_data["sample"].tolist() == [
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample1",
+        "sample2",
+        "sample3",
+    ]
+    assert pd_data["target"].tolist() == ["a", "b", "c", "a", "b", "c"]
+    assert set(pd_data[TARGET_COLUMN].tolist()) == set([0, 1, -1, 0, 1, -1])
+
+
+def test_biodata_load_dataset_with_multiple_files_and_positive_labels(
+    data_with_metadata, feature_metadata_file
+):
+    data = load_dataset(
+        "snp",
+        data_files=[data_with_metadata, data_with_metadata],
+        feature_metadata_files=feature_metadata_file,
+        positive_labels=["a", "b"],
+        target_column="target",
+    )["train"]
+    pd_data = data.to_pandas()
+    assert len(pd_data) == 6
+    assert pd_data["sample"].tolist() == [
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample1",
+        "sample2",
+        "sample3",
+    ]
+    assert pd_data["target"].tolist() == ["a", "b", "c", "a", "b", "c"]
+    assert set(pd_data[TARGET_COLUMN].tolist()) == set([1, 1, 0, 1, 1, 0])
+
+
+def test_biodata_load_dataset_with_multiple_files_and_negative_labels(
+    data_with_metadata, feature_metadata_file
+):
+    data = load_dataset(
+        "snp",
+        data_files=[data_with_metadata, data_with_metadata],
+        feature_metadata_files=feature_metadata_file,
+        negative_labels=["a", "b"],
+        target_column="target",
+    )["train"]
+    pd_data = data.to_pandas()
+    assert pd_data["sample"].tolist() == [
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample1",
+        "sample2",
+        "sample3",
+    ]
+    assert pd_data["target"].tolist() == ["a", "b", "c", "a", "b", "c"]
+    assert set(pd_data[TARGET_COLUMN].tolist()) == set([0, 0, 1, 0, 0, 1])
+
+
+def test_biodata_load_dataset_with_multiple_sample_files_and_labels(
+    npz_file, sample_metadata_file, sample_metadata_file_2, feature_metadata_file
+):
+    data = load_dataset(
+        "snp",
+        data_files=[npz_file, npz_file],
+        sample_metadata_files=[sample_metadata_file, sample_metadata_file],
+        feature_metadata_files=feature_metadata_file,
+        labels=["a", "b", "c"],
+        target_column="target",
+    )["train"]
+    pd_data = data.to_pandas()
+    assert pd_data["sample"].tolist() == [
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample1",
+        "sample2",
+        "sample3",
+    ]
+    assert pd_data["target"].tolist() == ["a", "b", "c", "a", "b", "c"]
+    assert set(pd_data[TARGET_COLUMN].tolist()) == set([0, 1, 2, 0, 1, 2])
 
 
 # class ModuleFactoryTest(TestCase):


### PR DESCRIPTION
Included the addition of a new `SchemaManager` class for infer the schema during downloads, and did updates to the `load_dataset` function to handle existing keyword arguments, and various improvements to error messages and logging.

### New Features:

* Added `SchemaManager` class to handle schema gathering during downloads and integrated it into the `src/biosets/download` module. (`src/biosets/download/__init__.py`, `src/biosets/download/schema_manager.py`) [[1]](diffhunk://#diff-74d50ac2ce8d609797825081366f4fe1759285c344084b10fd26c58b13e3cd1eR1) [[2]](diffhunk://#diff-85cf77d09e5a4486f92ad8f1717c978649d3e94156300eede86c267b0fbc890eR1-R116)

### Function Enhancements:

* Updated `load_dataset` function to check for existing keyword arguments before updating with new ones. (`src/biosets/load.py`) [[1]](diffhunk://#diff-feca7e7e8ed6712b7fb6782d256197981c991f03cdc274a5d3964b93b7832a47R152) [[2]](diffhunk://#diff-feca7e7e8ed6712b7fb6782d256197981c991f03cdc274a5d3964b93b7832a47L161-R201)
* Modified `_split_generators` in `biodata.py` to use `SchemaManager` for schema management when certain conditions are met. (`src/biosets/packaged_modules/biodata/biodata.py`)

### Error Messaging and Logging:

* Fixed where logs didn't have line breaks when a progress bar is present. (`src/biosets/packaged_modules/biodata/biodata.py`) [[1]](diffhunk://#diff-477f257b9fad7335fcf7adaf804049429861a58ae68d0028400422cad76b62f1L123-R133) [[2]](diffhunk://#diff-477f257b9fad7335fcf7adaf804049429861a58ae68d0028400422cad76b62f1L612-R617) [[3]](diffhunk://#diff-477f257b9fad7335fcf7adaf804049429861a58ae68d0028400422cad76b62f1L650-R655) [[4]](diffhunk://#diff-477f257b9fad7335fcf7adaf804049429861a58ae68d0028400422cad76b62f1L977-R945) [[5]](diffhunk://#diff-477f257b9fad7335fcf7adaf804049429861a58ae68d0028400422cad76b62f1L990-R958) [[6]](diffhunk://#diff-477f257b9fad7335fcf7adaf804049429861a58ae68d0028400422cad76b62f1L1355-R1328) [[7]](diffhunk://#diff-477f257b9fad7335fcf7adaf804049429861a58ae68d0028400422cad76b62f1L1434-R1402) [[8]](diffhunk://#diff-477f257b9fad7335fcf7adaf804049429861a58ae68d0028400422cad76b62f1L1444-R1412) [[9]](diffhunk://#diff-477f257b9fad7335fcf7adaf804049429861a58ae68d0028400422cad76b62f1L1463-R1431)